### PR TITLE
Renamed "Django.tmLanguage" to "HTML (Django).tmLanguage"

### DIFF
--- a/HTML (Django).tmLanguage
+++ b/HTML (Django).tmLanguage
@@ -12,7 +12,7 @@
 	<key>foldingStopMarker</key>
 	<string>({% (endblock|endcomment|endfor|endif|endifequal|endifnotequal|endspaceless|endwith|endblocktrans) %})</string>
 	<key>name</key>
-	<string>Django</string>
+	<string>HTML (Django)</string>
 	<key>patterns</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Renamed "Django.tmLanguage" to "HTML (Django).tmLanguage" so that it shows up grouped with the rest of the HTML syntax types in the "syntax" menu.
