### PR TITLE
Exclude quotes from the selection in the trans template tag

### DIFF
--- a/html/trans.sublime-snippet
+++ b/html/trans.sublime-snippet
@@ -1,6 +1,6 @@
 <!-- See http://www.sublimetext.com/docs/snippets for more information -->
 <snippet>
-	<content><![CDATA[{% trans ${1:"string to translate"} %}]]></content>
+	<content><![CDATA[{% trans "${1:string to translate}" %}]]></content>
     <tabTrigger>trans</tabTrigger>
     <scope>text.html.django</scope>
     <description>trans</description>


### PR DESCRIPTION
99% of times we're translating a string, not a variable.
