### PR TITLE
Add an ipdb debug snippet

### DIFF
--- a/python/ipdb.sublime-snippet
+++ b/python/ipdb.sublime-snippet
@@ -1,0 +1,7 @@
+<!-- See http://www.sublimetext.com/docs/snippets for more information -->
+<snippet>
+    <content><![CDATA[import ipdb; ipdb.set_trace()]]></content>
+    <tabTrigger>ipdb</tabTrigger>
+    <scope>source.python</scope>
+    <description>ipdb debug tool</description>
+</snippet>


### PR DESCRIPTION
Since you added in pdb, we may as well have the better one too, right? :)

A style change from the pdb snippet, this puts both statements on the one line, which makes things easier for debugging (one line to comment/remove).
If you don't like the inconsistancy between the snippets, I can change this or the other snippet to match at your choice (but really, one line is better ;)) 
