### PR TITLE
Adding simple quotes in string to highlight in django tags blocks 

### DIFF
--- a/Syntaxes/HTML (Django).tmLanguage
+++ b/Syntaxes/HTML (Django).tmLanguage
@@ -102,6 +102,14 @@
 					<string>storage.type.attr.django</string>
 				</dict>
 				<dict>
+                                        <key>begin</key>
+                                        <string>:'|'</string>
+                                        <key>end</key>
+                                        <string>'</string>
+                                        <key>name</key>
+                                        <string>storage.type.attr.django</string>
+                                </dict>
+				<dict>
 					<key>match</key>
 					<string>\|</string>
 					<key>name</key>


### PR DESCRIPTION
Now it is possible to white django blocks with simple quotes:
{% trans 'some value' %}
and also
{[ somevar|add:'2' }}
