### PR TITLE
Added a traceback.print_exc() python snippet

### DIFF
--- a/python/traceback.sublime-snippet
+++ b/python/traceback.sublime-snippet
@@ -1,0 +1,7 @@
+<!-- See http://www.sublimetext.com/docs/snippets for more information -->
+<snippet>
+    <content><![CDATA[import traceback; traceback.print_exc();]]></content>
+    <tabTrigger>traceback</tabTrigger>
+    <scope>source.python</scope>
+    <description>traceback print exception</description>
+</snippet>


### PR DESCRIPTION
Added a traceback.print_exc() snippet, useful to print traceback info while debugging, in try/except blocks.
