### PR TITLE
Dispatch snippet must return a value

### DIFF
--- a/Views/dispatch.sublime-snippet
+++ b/Views/dispatch.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[
 def dispatch(self, request, *args, **kwargs):
-    super(${1:CLASS_NAME}, self).dispatch(request, *args, **kwargs)
+    return super(${1:CLASS_NAME}, self).dispatch(request, *args, **kwargs)
 ]]></content>
 	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>dispatch</tabTrigger>


### PR DESCRIPTION
I fixed dispatch snippet because it didn't return anything by default and this could lead to many bugs and annoyances
