### PR TITLE
Remove `u` from some strings

### DIFF
--- a/Python (Django).sublime-completions
+++ b/Python (Django).sublime-completions
@@ -20,15 +20,15 @@
 		{ "trigger": "unique_for_date", "contents": "unique_for_date='$1'" },
 		{ "trigger": "unique_for_month", "contents": "unique_for_month='$1'" },
 		{ "trigger": "unique_for_year", "contents": "unique_for_year='$1'" },
-		{ "trigger": "verbose_name", "contents": "verbose_name=u'$1'" },
+		{ "trigger": "verbose_name", "contents": "verbose_name='$1'" },
 		{ "trigger": "validators", "contents": "validators=[$1]" },
 		{ "trigger": "auto_now_add", "contents": "auto_now_add=${1:True}" },
 		{ "trigger": "auto_now", "contents": "auto_now=${1:True}" },
 		{ "trigger": "max_length", "contents": "max_length=$1" },
 
 		{ "trigger": "meta_ut", "contents": "unique_together = ('$1',)" },
-		{ "trigger": "meta_vn", "contents": "verbose_name = u'$1'" },
-		{ "trigger": "meta_vnp", "contents": "verbose_name_plural = u'$1'" },
+		{ "trigger": "meta_vn", "contents": "verbose_name = '$1'" },
+		{ "trigger": "meta_vnp", "contents": "verbose_name_plural = '$1'" },
 
 		{ "trigger": "required", "contents": "required=${1:True}" },
 		{ "trigger": "label", "contents": "label='$1'" },


### PR DESCRIPTION
It's better to use strings directly instead of explicit unicode string. If someone want unicode in theirs  Python 2 project they can add `from __future__ import unicode_literals` at the beginning of the file.
