### PR TITLE
Update mac path with second backslashes in accordance with reSructuredText backslashes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Installation
 1. Clone this repo
 2. Put the contents of this repo directly inside:
 
- - OS X: ~/Library/Application"\\" Support/Sublime"\\" Text"\\" 2/Packages
+ - OS X: ~/Library/Application\\ Support/Sublime\\ Text\\ 2/Packages
  - Windows: %APPDATA%/Sublime Text 2/Packages/
  - Linux: ~/.config/sublime-text-2/Packages
 


### PR DESCRIPTION
reSructuredText files needs double backslashes to render one, path for mac is now updated.
