### PR TITLE
Fixed typos in model admin view snippet

### DIFF
--- a/Views/AdminView.sublime-snippet
+++ b/Views/AdminView.sublime-snippet
@@ -1,19 +1,19 @@
 <snippet>
     <content><![CDATA[
 class ${1}Admin(admin.ModelAdmin):
-        '''
-            Admin View for ${1}
-        '''
-        list_display = ('${2}',)
-        list_filter = ('${3}',)
-        inlines = [
-            ${4}Inline,
-        ]
-        raw_id_fields = ('${5}',)
-        readonly_fields = ('${6}',)
-        search_fields = ['${7}']
+    '''
+        Admin View for ${1}
+    '''
+    list_display = ('${2}',)
+    list_filter = ('${3}',)
+    inlines = [
+        ${4}Inline,
+    ]
+    raw_id_fields = ('${5}',)
+    readonly_fields = ('${6}',)
+    search_fields = ['${7}']
 
-admin.register(${1}, ${1}Admin)
+admin.site.register(${1}, ${1}Admin)
 ]]></content>
     <tabTrigger>adminview</tabTrigger>
     <scope>source.python</scope>


### PR DESCRIPTION
For whatever reason, there were 6 spaces of indentation when used in Sublime, which caused an error, and admin.register should be admin.site.register
