### PR TITLE
Added "new django site" functionality to Sublime Text Sidebar

### DIFF
--- a/Commands.sublime-commands
+++ b/Commands.sublime-commands
@@ -1,0 +1,6 @@
+[
+    {
+        "caption": "Django: Create New Project (relative to Open File)",
+        "command": "relativedjango"
+    }
+    ]

--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -1,0 +1,4 @@
+[
+	{"caption":"New Django Project",
+	"command" : "relativedjango"}
+]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -50,4 +50,19 @@
             }
         ]
     }
+    {
+        "caption": "Tools",
+        "mnemonic": "t",
+        "id": "tools",
+
+        "children":
+        [
+            {
+                "caption":"New Django Site",
+                "command" : "relativedjango",
+
+            },
+
+        ]
+    }
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -59,9 +59,9 @@
         [
             {
                 "caption":"New Django Site",
-                "command" : "relativedjango",
+                "command" : "relativedjango"
 
-            },
+            }
 
         ]
     }

--- a/Side Bar.sublime-menu
+++ b/Side Bar.sublime-menu
@@ -1,0 +1,1 @@
+[{ "caption": "New Django Site", 	      "id": "django-project",         "command": "newdjango","args": {"paths": []}}]

--- a/djangoFileCode.py
+++ b/djangoFileCode.py
@@ -1,0 +1,139 @@
+def MANAGE_PY(project):
+	return '''import os
+import sys
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{0}.settings")
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)
+'''.format(project)
+def APP_ADMIN():
+	return '''from django.contrib import admin
+
+# Register your models here.
+'''
+def APP_VIEWS():
+	return '''from django.shortcuts import render
+
+# Create your views here.
+'''
+def APP_MODELS():
+	return '''from django.db import models
+
+# Create your models here.
+'''
+def APP_TESTS():
+	return '''from django.test import TestCase
+
+# Create your tests here.'''
+def WSGI_PY(project):
+	return '''import os
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{0}.settings")
+
+from django.core.wsgi import get_wsgi_application
+application = get_wsgi_application()
+'''.format(project)
+def URLS_PY():
+	return '''from django.conf.urls import patterns, include, url
+from django.contrib import admin
+
+urlpatterns = patterns('',
+    # Examples:
+    # url(r'^$', 'untitled3.views.home', name='home'),
+    # url(r'^blog/', include('blog.urls')),
+
+    url(r'^admin/', include(admin.site.urls)),
+)
+'''
+def SETTINGS_PY(project,app):
+	return '''"""
+Django settings for untitled3 project.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/1.7/topics/settings/
+
+For the full list of settings and their values, see
+https://docs.djangoproject.com/en/1.7/ref/settings/
+"""
+
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+import os
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+
+
+# Quick-start development settings - unsuitable for production
+# See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = 'nb812krd_^=9gzv#rpi@xfyjgdiiy*lv_nw46c)754xrxepwe$'
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True
+
+TEMPLATE_DEBUG = True
+
+ALLOWED_HOSTS = []
+
+
+# Application definition
+
+INSTALLED_APPS = (
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    '%s',
+)
+
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+)
+
+ROOT_URLCONF = '%s.urls'
+
+WSGI_APPLICATION = '%s.wsgi.application'
+
+
+# Database
+# https://docs.djangoproject.com/en/1.7/ref/settings/#databases
+
+DATABASES = {
+
+    'default'  : {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    }
+}
+
+# Internationalization
+# https://docs.djangoproject.com/en/1.7/topics/i18n/
+
+LANGUAGE_CODE = 'en-us'
+
+TIME_ZONE = 'UTC'
+
+USE_I18N = True
+
+USE_L10N = True
+
+USE_TZ = True
+
+
+# Static files (CSS, JavaScript, Images)
+# https://docs.djangoproject.com/en/1.7/howto/static-files/
+
+STATIC_URL = '/static/'
+
+TEMPLATE_DIRS = (
+    os.path.join(BASE_DIR,  'templates'),
+)'''% (app,project,project)

--- a/djangoFileCode.py
+++ b/djangoFileCode.py
@@ -1,139 +1,164 @@
-def MANAGE_PY(project):
-	return '''import os
-import sys
+import textwrap
 
-if __name__ == "__main__":
+
+def MANAGE_PY(project):
+    return textwrap.dedent('''\
+    import os
+    import sys
+
+    if __name__ == "__main__":
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{0}.settings")
+
+        from django.core.management import execute_from_command_line
+
+        execute_from_command_line(sys.argv)
+    '''.format(project)).strip()
+
+
+def APP_ADMIN():
+    return textwrap.dedent('''\
+    from django.contrib import admin
+
+    # Register your models here.
+    ''').strip()
+
+
+def APP_VIEWS():
+    return textwrap.dedent('''\
+    from django.shortcuts import render
+
+    # Create your views here.
+    ''').strip()
+
+
+def APP_MODELS():
+    return textwrap.dedent('''\
+    from django.db import models
+
+    # Create your models here.
+    ''').strip()
+
+
+def APP_TESTS():
+    return textwrap.dedent('''\
+    from django.test import TestCase
+
+    # Create your tests here.''').strip()
+
+
+def WSGI_PY(project):
+    return textwrap.dedent('''\
+    import os
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{0}.settings")
 
-    from django.core.management import execute_from_command_line
+    from django.core.wsgi import get_wsgi_application
+    application = get_wsgi_application()
+    '''.format(project)).strip()
 
-    execute_from_command_line(sys.argv)
-'''.format(project)
-def APP_ADMIN():
-	return '''from django.contrib import admin
 
-# Register your models here.
-'''
-def APP_VIEWS():
-	return '''from django.shortcuts import render
-
-# Create your views here.
-'''
-def APP_MODELS():
-	return '''from django.db import models
-
-# Create your models here.
-'''
-def APP_TESTS():
-	return '''from django.test import TestCase
-
-# Create your tests here.'''
-def WSGI_PY(project):
-	return '''import os
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{0}.settings")
-
-from django.core.wsgi import get_wsgi_application
-application = get_wsgi_application()
-'''.format(project)
 def URLS_PY():
-	return '''from django.conf.urls import patterns, include, url
-from django.contrib import admin
+    return textwrap.dedent('''\
+    from django.conf.urls import patterns, include, url
+    from django.contrib import admin
 
-urlpatterns = patterns('',
-    # Examples:
-    # url(r'^$', 'untitled3.views.home', name='home'),
-    # url(r'^blog/', include('blog.urls')),
+    urlpatterns = patterns('',
+        # Examples:
+        # url(r'^$', 'untitled3.views.home', name='home'),
+        # url(r'^blog/', include('blog.urls')),
 
-    url(r'^admin/', include(admin.site.urls)),
-)
-'''
-def SETTINGS_PY(project,app):
-	return '''"""
-Django settings for untitled3 project.
-
-For more information on this file, see
-https://docs.djangoproject.com/en/1.7/topics/settings/
-
-For the full list of settings and their values, see
-https://docs.djangoproject.com/en/1.7/ref/settings/
-"""
-
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-import os
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+        url(r'^admin/', include(admin.site.urls)),
+    )
+    ''').strip()
 
 
-# Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
+def SETTINGS_PY(project, app):
+    return textwrap.dedent('''\
+    """
+    Django settings for untitled3 project.
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'nb812krd_^=9gzv#rpi@xfyjgdiiy*lv_nw46c)754xrxepwe$'
+    For more information on this file, see
+    https://docs.djangoproject.com/en/1.7/topics/settings/
 
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+    For the full list of settings and their values, see
+    https://docs.djangoproject.com/en/1.7/ref/settings/
+    """
 
-TEMPLATE_DEBUG = True
-
-ALLOWED_HOSTS = []
-
-
-# Application definition
-
-INSTALLED_APPS = (
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    '%s',
-)
-
-MIDDLEWARE_CLASSES = (
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-)
-
-ROOT_URLCONF = '%s.urls'
-
-WSGI_APPLICATION = '%s.wsgi.application'
+    # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+    import os
+    BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 
-# Database
-# https://docs.djangoproject.com/en/1.7/ref/settings/#databases
+    # Quick-start development settings - unsuitable for production
+    # See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
 
-DATABASES = {
+    # SECURITY WARNING: keep the secret key used in production secret!
+    SECRET_KEY = 'nb812krd_^=9gzv#rpi@xfyjgdiiy*lv_nw46c)754xrxepwe$'
 
-    'default'  : {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    # SECURITY WARNING: don't run with debug turned on in production!
+    DEBUG = True
+
+    TEMPLATE_DEBUG = True
+
+    ALLOWED_HOSTS = []
+
+
+    # Application definition
+
+    INSTALLED_APPS = (
+        'django.contrib.admin',
+        'django.contrib.auth',
+        'django.contrib.contenttypes',
+        'django.contrib.sessions',
+        'django.contrib.messages',
+        'django.contrib.staticfiles',
+        '%s',
+    )
+
+    MIDDLEWARE_CLASSES = (
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.common.CommonMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    )
+
+    ROOT_URLCONF = '%s.urls'
+
+    WSGI_APPLICATION = '%s.wsgi.application'
+
+
+    # Database
+    # https://docs.djangoproject.com/en/1.7/ref/settings/#databases
+
+    DATABASES = {
+
+        'default'  : {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        }
     }
-}
 
-# Internationalization
-# https://docs.djangoproject.com/en/1.7/topics/i18n/
+    # Internationalization
+    # https://docs.djangoproject.com/en/1.7/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+    LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+    TIME_ZONE = 'UTC'
 
-USE_I18N = True
+    USE_I18N = True
 
-USE_L10N = True
+    USE_L10N = True
 
-USE_TZ = True
+    USE_TZ = True
 
 
-# Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/1.7/howto/static-files/
+    # Static files (CSS, JavaScript, Images)
+    # https://docs.djangoproject.com/en/1.7/howto/static-files/
 
-STATIC_URL = '/static/'
+    STATIC_URL = '/static/'
 
-TEMPLATE_DIRS = (
-    os.path.join(BASE_DIR,  'templates'),
-)'''% (app,project,project)
+    TEMPLATE_DIRS = (
+        os.path.join(BASE_DIR,  'templates'),
+    )''' % (app, project, project)).strip()

--- a/djangostarter.py
+++ b/djangostarter.py
@@ -1,0 +1,66 @@
+import sublime,sublime_plugin,os
+
+try:
+	from .djangoFileCode import *
+except:
+	from djangoFileCode import *
+
+class DjangoCreate:
+	@staticmethod
+	def createMainFolder(path,project,app):
+		path=path[0]+'\\'+ project
+		if not os.path.exists(path):
+			os.makedirs(path)
+		return path
+	@staticmethod 
+	def createProjectFiles(location,project,app):
+		pathsToCreate = [location+'\\'+a for a in [project,app,'templates']]
+		for path in pathsToCreate:
+			if not os.path.exists(path):
+				os.makedirs(path)
+		with open(location+'\\manage.py','w') as f:
+			f.write(MANAGE_PY(project))
+		projectSitePath = location + '\\' + project
+		projectSiteFiles={'__init__.py':'','settings.py':SETTINGS_PY(project,app),'urls.py':URLS_PY(),'wsgi.py':WSGI_PY(project)}
+		for key in projectSiteFiles.keys():
+			with open(projectSitePath+'\\'+key,'w') as f:
+				f.write(projectSiteFiles[key])
+		appPath = location + '\\' + app 
+		if not os.path.exists(appPath+'\\migrations'):
+			os.makedirs(appPath+'\\migrations')
+		appFiles={'__init__.py':'','admin.py':APP_ADMIN(),'models.py':APP_MODELS(),'tests.py':APP_TESTS(),'views.py':APP_VIEWS()}
+		for key in appFiles.keys():
+			with open(appPath+'\\'+key,'w') as f:
+				f.write(appFiles[key])
+		return location+'\\manage.py'
+
+class NewdjangoCommand(sublime_plugin.WindowCommand):
+	def run(self,paths=[]):
+		self.path=paths 
+		self.window.show_input_panel("Django Project Name:", '', lambda s: self.getAppName(s), None, None)
+	def getAppName(self,project):
+		self.project=project
+		self.window.show_input_panel("Django App Name:", '', lambda s: self.doRest(s), None, None)
+	def doRest(self,appName):
+		for index,elem in enumerate(self.path):
+			if '.' in elem:
+				self.path[index]=elem.replace(elem.split('\\')[-1],'')
+		p = DjangoCreate.createMainFolder(self.path,self.project,appName)
+		manage = DjangoCreate.createProjectFiles(p,self.project,appName)
+		self.window.open_file(manage)
+		
+class RelativedjangoCommand(sublime_plugin.TextCommand):
+	def run(self,edit):
+		f=self.view.file_name()
+		self.path=[self.getFolderName(f)]
+		sublime.active_window().show_input_panel("Django Project Name:", '', lambda s: self.rest(s), None, None)
+	def rest(self,project):
+		self.project=project 
+		sublime.active_window().show_input_panel("Django App Name:", '', lambda s: self.final(s), None, None)
+	def final(self,app):
+		self.app=app 
+		p = DjangoCreate.createMainFolder(self.path,self.project,self.app)
+		manage = DjangoCreate.createProjectFiles(p,self.project,self.app)
+		sublime.active_window().open_file(manage)
+	def getFolderName(self,file):
+		return file.replace(file.split('\\')[-1],'')

--- a/djangostarter.py
+++ b/djangostarter.py
@@ -1,66 +1,95 @@
-import sublime,sublime_plugin,os
-
+import sublime
+import sublime_plugin
+import os
+join = os.path.join
 try:
-	from .djangoFileCode import *
+    from .djangoFileCode import *
 except:
-	from djangoFileCode import *
+    from djangoFileCode import *
+
 
 class DjangoCreate:
-	@staticmethod
-	def createMainFolder(path,project,app):
-		path=path[0]+'\\'+ project
-		if not os.path.exists(path):
-			os.makedirs(path)
-		return path
-	@staticmethod 
-	def createProjectFiles(location,project,app):
-		pathsToCreate = [location+'\\'+a for a in [project,app,'templates']]
-		for path in pathsToCreate:
-			if not os.path.exists(path):
-				os.makedirs(path)
-		with open(location+'\\manage.py','w') as f:
-			f.write(MANAGE_PY(project))
-		projectSitePath = location + '\\' + project
-		projectSiteFiles={'__init__.py':'','settings.py':SETTINGS_PY(project,app),'urls.py':URLS_PY(),'wsgi.py':WSGI_PY(project)}
-		for key in projectSiteFiles.keys():
-			with open(projectSitePath+'\\'+key,'w') as f:
-				f.write(projectSiteFiles[key])
-		appPath = location + '\\' + app 
-		if not os.path.exists(appPath+'\\migrations'):
-			os.makedirs(appPath+'\\migrations')
-		appFiles={'__init__.py':'','admin.py':APP_ADMIN(),'models.py':APP_MODELS(),'tests.py':APP_TESTS(),'views.py':APP_VIEWS()}
-		for key in appFiles.keys():
-			with open(appPath+'\\'+key,'w') as f:
-				f.write(appFiles[key])
-		return location+'\\manage.py'
 
-class NewdjangoCommand(sublime_plugin.WindowCommand):
-	def run(self,paths=[]):
-		self.path=paths 
-		self.window.show_input_panel("Django Project Name:", '', lambda s: self.getAppName(s), None, None)
-	def getAppName(self,project):
-		self.project=project
-		self.window.show_input_panel("Django App Name:", '', lambda s: self.doRest(s), None, None)
-	def doRest(self,appName):
-		for index,elem in enumerate(self.path):
-			if '.' in elem:
-				self.path[index]=elem.replace(elem.split('\\')[-1],'')
-		p = DjangoCreate.createMainFolder(self.path,self.project,appName)
-		manage = DjangoCreate.createProjectFiles(p,self.project,appName)
-		self.window.open_file(manage)
-		
-class RelativedjangoCommand(sublime_plugin.TextCommand):
-	def run(self,edit):
-		f=self.view.file_name()
-		self.path=[self.getFolderName(f)]
-		sublime.active_window().show_input_panel("Django Project Name:", '', lambda s: self.rest(s), None, None)
-	def rest(self,project):
-		self.project=project 
-		sublime.active_window().show_input_panel("Django App Name:", '', lambda s: self.final(s), None, None)
-	def final(self,app):
-		self.app=app 
-		p = DjangoCreate.createMainFolder(self.path,self.project,self.app)
-		manage = DjangoCreate.createProjectFiles(p,self.project,self.app)
-		sublime.active_window().open_file(manage)
-	def getFolderName(self,file):
-		return file.replace(file.split('\\')[-1],'')
+    @staticmethod
+    def createMainFolder(path, project, app):
+        path = path[0] + '\\' + project
+        if not os.path.exists(path):
+            os.makedirs(path)
+        return path
+
+    @staticmethod
+    def createProjectFiles(location, project, app):
+        pathsToCreate = [
+            join(location,a) for a in [project, app, 'templates']]
+
+        for path in pathsToCreate:
+            if not os.path.exists(path):
+                os.makedirs(path)
+
+        with open(join(location,'manage.py'), 'w') as f:
+            f.write(MANAGE_PY(project))
+
+        projectSitePath = join(location, project)
+
+        projectSiteFiles = {'__init__.py': '', 'settings.py': SETTINGS_PY(
+            project, app), 'urls.py': URLS_PY(), 'wsgi.py': WSGI_PY(project)}
+
+        for key in projectSiteFiles.keys():
+            with open(join(projectSitePath,key), 'w') as f:
+                f.write(projectSiteFiles[key])
+
+        appPath = join(location,app)
+        if not os.path.exists(join(appPath,'migrations')):
+            os.makedirs(join(appPath,'migrations'))
+
+        appFiles = {'__init__.py': '', 'admin.py': APP_ADMIN(
+        ), 'models.py': APP_MODELS(), 'tests.py': APP_TESTS(), 'views.py': APP_VIEWS()}
+
+        for key in appFiles.keys():
+            with open(join(appPath, key), 'w') as f:
+                f.write(appFiles[key])
+        return join(location, 'manage.py')
+
+
+class NewDjangoCommand(sublime_plugin.WindowCommand):
+
+    def run(self, paths=[]):
+        self.path = paths
+        self.window.show_input_panel(
+            "Django Project Name:", '', lambda s: self.getAppName(s), None, None)
+
+    def getAppName(self, project):
+        self.project = project
+        self.window.show_input_panel(
+            "Django App Name:", '', lambda s: self.doRest(s), None, None)
+
+    def doRest(self, appName):
+        for index, elem in enumerate(self.path):
+            if '.' in elem:
+                self.path[index] = elem.replace(elem.split('\\')[-1], '')
+        p = DjangoCreate.createMainFolder(self.path, self.project, appName)
+        manage = DjangoCreate.createProjectFiles(p, self.project, appName)
+        self.window.open_file(manage)
+
+
+class RelativeDjangoCommand(sublime_plugin.TextCommand):
+
+    def run(self, edit):
+        f = self.view.file_name()
+        self.path = [self.getFolderName(f)]
+        sublime.active_window().show_input_panel(
+            "Django Project Name:", '', lambda s: self.rest(s), None, None)
+
+    def rest(self, project):
+        self.project = project
+        sublime.active_window().show_input_panel(
+            "Django App Name:", '', lambda s: self.final(s), None, None)
+
+    def final(self, app):
+        self.app = app
+        p = DjangoCreate.createMainFolder(self.path, self.project, self.app)
+        manage = DjangoCreate.createProjectFiles(p, self.project, self.app)
+        sublime.active_window().open_file(manage)
+
+    def getFolderName(self, file):
+        return file.replace(file.split('\\')[-1], '')


### PR DESCRIPTION
Well, firstly this plugin is awesome and very helpful whenever I'm coding Django Sites. One thing about Django that sucked (well to me) that to create a project, I have to use django_admin.py to create and config all the files. Well the Plugin that I've created (and added to this fork) minimizes all of that and does most of the grunt work (setting up the files) itself. Creating Django project from Sublime Text itself.

It's compatible with both ST3 and ST2.
Hope you merge my fork. I'm using this fork on my local machine and it's working nicely.