### PR TITLE
add the template tag 'verbatim' to syntax highlighting and code snippets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,7 @@ Snippets for Django templates
  static          ``{% static %}``
  templatetag     ``{% templatetag %}``
  url             ``{% url %}``
+ verbatim        ``{% verbatim %} {% endverbatim %}``
  widthratio      ``{% widthratio %}``
  with            ``{% with as %} {% endwith %}``
  trans           ``{% trans %}``

--- a/Syntaxes/HTML (Django).JSON-tmLanguage
+++ b/Syntaxes/HTML (Django).JSON-tmLanguage
@@ -71,7 +71,7 @@
             "patterns": [
                 {
                     "name": "keyword.control.tag-name.django",
-                    "match": "\\b(autoescape|endautoescape|block|endblock|blocktrans|endblocktrans|trans|plural|debug|extends|filter|firstof|for|empty|endfor|if|elif|else|endif|include|ifchanged|endifchanged|ifequal|endifequal|ifnotequal|endifnotequal|load|from|low|regroup|ssi|spaceless|endspaceless|templatetag|widthratio|with|endwith|csrf_token|cycle|url|lorem|thumbnail|endthumbnail|get_static_prefix)\\b"
+                    "match": "\\b(autoescape|endautoescape|block|endblock|blocktrans|endblocktrans|trans|plural|debug|extends|filter|firstof|for|empty|endfor|if|elif|else|endif|include|ifchanged|endifchanged|ifequal|endifequal|ifnotequal|endifnotequal|load|from|low|regroup|ssi|spaceless|endspaceless|templatetag|widthratio|with|endwith|csrf_token|cycle|url|verbatim|endverbatim|lorem|thumbnail|endthumbnail|get_static_prefix)\\b"
                 },
                 {
                     "name": "keyword.operator.django",

--- a/Syntaxes/HTML (Django).tmLanguage
+++ b/Syntaxes/HTML (Django).tmLanguage
@@ -756,7 +756,7 @@
 				<array>
 					<dict>
 						<key>match</key>
-						<string>\b(autoescape|endautoescape|block|endblock|blocktrans|endblocktrans|trans|plural|debug|extends|filter|firstof|for|empty|endfor|if|elif|else|endif|include|ifchanged|endifchanged|ifequal|endifequal|ifnotequal|endifnotequal|load|from|low|regroup|ssi|spaceless|endspaceless|templatetag|widthratio|with|endwith|csrf_token|cycle|url|lorem|thumbnail|endthumbnail|get_static_prefix)\b</string>
+						<string>\b(autoescape|endautoescape|block|endblock|blocktrans|endblocktrans|trans|plural|debug|extends|filter|firstof|for|empty|endfor|if|elif|else|endif|include|ifchanged|endifchanged|ifequal|endifequal|ifnotequal|endifnotequal|load|from|low|regroup|ssi|spaceless|endspaceless|templatetag|widthratio|with|endwith|csrf_token|cycle|url|verbatim|endverbatim|lorem|thumbnail|endthumbnail|get_static_prefix)\b</string>
 						<key>name</key>
 						<string>keyword.control.tag-name.django</string>
 					</dict>

--- a/html/verbatim.sublime-snippet
+++ b/html/verbatim.sublime-snippet
@@ -1,0 +1,11 @@
+<!-- See http://www.sublimetext.com/docs/snippets for more information -->
+<snippet>
+	<content><![CDATA[
+{% verbatim %}
+	${1:$SELECTION}
+{% endverbatim %}
+]]>	</content>
+    <tabTrigger>verbatim</tabTrigger>
+    <scope>text.html.django</scope>
+    <description>verbatim</description>
+</snippet>


### PR DESCRIPTION
It's my first time contributing to a sublime package. Did I forget something? Issue #51 