### PR TITLE
Use reverse instead @models.permalink in "Model (full)"

### DIFF
--- a/Models/Classes/Model With Methods.sublime-snippet
+++ b/Models/Classes/Model With Methods.sublime-snippet
@@ -2,7 +2,7 @@
 <snippet>
     <content><![CDATA[
 class ${1:MODELNAME}(models.Model):
-    ${2:# TODO: Define fields here}
+    ${3:# TODO: Define fields here}
 
     class Meta:
         verbose_name = "$1"
@@ -17,7 +17,7 @@ class ${1:MODELNAME}(models.Model):
     def get_absolute_url(self):
         return reverse('${2:APP_NAME}:details', kwargs={'slug': self.slug})
 
-    ${3:# TODO: Define custom methods here}
+    ${4:# TODO: Define custom methods here}
 
     ]]></content>
     <tabTrigger>Model_full</tabTrigger>

--- a/Models/Classes/Model With Methods.sublime-snippet
+++ b/Models/Classes/Model With Methods.sublime-snippet
@@ -14,9 +14,8 @@ class ${1:MODELNAME}(models.Model):
     def save(self):
         pass
 
-    @models.permalink
     def get_absolute_url(self):
-        return ('')
+        return reverse('${2:APP_NAME}:details', kwargs={'slug': self.slug})
 
     ${3:# TODO: Define custom methods here}
 


### PR DESCRIPTION
Why??

> Warning
> The permalink decorator is no longer recommended. You should use reverse() in the body of your get_absolute_url method instead.
> https://docs.djangoproject.com/en/1.7/ref/models/instances/
