### PR TITLE
Add fields attribute to the ModelForm snippet

### DIFF
--- a/Forms/Classes/ModelForm.sublime-snippet
+++ b/Forms/Classes/ModelForm.sublime-snippet
@@ -4,6 +4,7 @@
 class ${1:MODELNAME}Form(forms.ModelForm):
     class Meta:
         model = $1
+        fields = ['$2',]
     ]]></content>
     <tabTrigger>ModelForm</tabTrigger>
     <scope>source.python</scope>

--- a/Forms/Classes/ModelForm.sublime-snippet
+++ b/Forms/Classes/ModelForm.sublime-snippet
@@ -4,7 +4,7 @@
 class ${1:MODELNAME}Form(forms.ModelForm):
     class Meta:
         model = $1
-        fields = ['$2',]
+        fields = ('$2',)
     ]]></content>
     <tabTrigger>ModelForm</tabTrigger>
     <scope>source.python</scope>


### PR DESCRIPTION
Quoting the official documentation:

> It is strongly recommended that you explicitly set all fields that should be edited in the form using the `fields` attribute. Failure to do so can easily lead to security problems when a form unexpectedly allows a user to set certain fields, especially when new fields are added to a model. Depending on how the form is rendered, the problem may not even be visible on the web page.