### PR TITLE
Default to single instead of double quotes

### DIFF
--- a/html/static.sublime-snippet
+++ b/html/static.sublime-snippet
@@ -1,6 +1,6 @@
 <!-- See http://www.sublimetext.com/docs/snippets for more information -->
 <snippet>
-    <content><![CDATA[{% static "${1:$SELECTION}" %}]]></content>
+    <content><![CDATA[{% static '${1:$SELECTION}' %}]]></content>
     <tabTrigger>static</tabTrigger>
     <scope>text.html.django</scope>
     <description>static</description>


### PR DESCRIPTION
Static tag is typically used to get the url of static assets for use in tags like img, script and link.  Defaulting to double quotes screws up syntax highlighting for editors because the default delimiter in html is the double quote.