### PR TITLE
URL tag with quotes

### DIFF
--- a/html/url.sublime-snippet
+++ b/html/url.sublime-snippet
@@ -1,6 +1,6 @@
 <!-- See http://www.sublimetext.com/docs/snippets for more information -->
 <snippet>
-	<content><![CDATA[{% url $1 %}]]></content>
+	<content><![CDATA[{% url '$1' %}]]></content>
     <tabTrigger>url</tabTrigger>
     <scope>text.html.django</scope>
     <description>url</description>


### PR DESCRIPTION
New version of Django requires `url` tag with quotes.