### PR TITLE
Updates snippets to use django 4.0 models

### DIFF
--- a/Models/Model Fields/BinaryField (m_bin).sublime-snippet
+++ b/Models/Model Fields/BinaryField (m_bin).sublime-snippet
@@ -1,0 +1,7 @@
+<!-- See http://www.sublimetext.com/docs/snippets for more information -->
+<snippet>
+    <content><![CDATA[${1:FIELDNAME} = models.BinaryField(max_length=${2:None})]]></content>
+    <tabTrigger>mbin</tabTrigger>
+    <scope>source.python</scope>
+    <description>BinaryField (mbin)</description>
+</snippet>

--- a/Models/Model Fields/CommaSeparatedIntegerField (m_coseint).sublime-snippet
+++ b/Models/Model Fields/CommaSeparatedIntegerField (m_coseint).sublime-snippet
@@ -1,7 +1,0 @@
-<!-- See http://www.sublimetext.com/docs/snippets for more information -->
-<snippet>
-    <content><![CDATA[${1:FIELDNAME} = models.CommaSeparatedIntegerField($2)]]></content>
-    <tabTrigger>mcoseint</tabTrigger>
-    <scope>source.python</scope>
-    <description>CommaSeparatedIntegerField (mcoseint)</description>
-</snippet>

--- a/Models/Model Fields/IPAddressField (m_ip).sublime-snippet
+++ b/Models/Model Fields/IPAddressField (m_ip).sublime-snippet
@@ -1,7 +1,0 @@
-<!-- See http://www.sublimetext.com/docs/snippets for more information -->
-<snippet>
-    <content><![CDATA[${1:FIELDNAME} = models.IPAddressField($2)]]></content>
-    <tabTrigger>mip</tabTrigger>
-    <scope>source.python</scope>
-    <description>IPAddressField (mip)</description>
-</snippet>

--- a/Models/Model Fields/JSONField (m_json).sublime-snippet
+++ b/Models/Model Fields/JSONField (m_json).sublime-snippet
@@ -1,0 +1,7 @@
+<!-- See http://www.sublimetext.com/docs/snippets for more information -->
+<snippet>
+    <content><![CDATA[${1:FIELDNAME} = models.JSONField($2)]]></content>
+    <tabTrigger>mjson</tabTrigger>
+    <scope>source.python</scope>
+    <description>JSONField (mjson)</description>
+</snippet>

--- a/Models/Model Fields/NullBooleanField (m_nullbool).sublime-snippet
+++ b/Models/Model Fields/NullBooleanField (m_nullbool).sublime-snippet
@@ -1,6 +1,6 @@
 <!-- See http://www.sublimetext.com/docs/snippets for more information -->
 <snippet>
-    <content><![CDATA[${1:FIELDNAME} = models.NullBooleanField($2)]]></content>
+    <content><![CDATA[${1:FIELDNAME} = models.BooleanField(null=True)]]></content>
     <tabTrigger>mnullbool</tabTrigger>
     <scope>source.python</scope>
     <description>NullBooleanField (mnullbool)</description>

--- a/Models/Model Fields/PositiveBigIntegerField (m_posbigint).sublime-snippet
+++ b/Models/Model Fields/PositiveBigIntegerField (m_posbigint).sublime-snippet
@@ -1,0 +1,7 @@
+<!-- See http://www.sublimetext.com/docs/snippets for more information -->
+<snippet>
+    <content><![CDATA[${1:FIELDNAME} = models.PositiveBigIntegerField($2)]]></content>
+    <tabTrigger>mposbigint</tabTrigger>
+    <scope>source.python</scope>
+    <description>PositiveSmallIntegerField (mposbigint)</description>
+</snippet>

--- a/Models/Model Fields/SmallAutoField (m_sauto).sublime-snippet
+++ b/Models/Model Fields/SmallAutoField (m_sauto).sublime-snippet
@@ -1,0 +1,7 @@
+<!-- See http://www.sublimetext.com/docs/snippets for more information -->
+<snippet>
+	<content><![CDATA[${1:FIELDNAME} = models.SmallAutoField($2)]]></content>
+	<tabTrigger>msauto</tabTrigger>
+    <scope>source.python</scope>
+    <description>SmallAutoField (msauto)</description>
+</snippet>

--- a/Models/Model Fields/XMLField (m_xml).sublime-snippet
+++ b/Models/Model Fields/XMLField (m_xml).sublime-snippet
@@ -1,7 +1,0 @@
-<!-- See http://www.sublimetext.com/docs/snippets for more information -->
-<snippet>
-    <content><![CDATA[${1:FIELDNAME} = models.XMLField($2)]]></content>
-    <tabTrigger>mxml</tabTrigger>
-    <scope>source.python</scope>
-    <description>XMLField (mxml)</description>
-</snippet>


### PR DESCRIPTION
Removes deprecated and removed CommaSeperatedInteger, IPAddressField, XML fields.  Adds Binary, JSON, BigInteger, and SmallAuto fields. NullBoolean now creates `BooleanField(null=True)`.