### PR TITLE
Bug fix for multiline comments, and scoping fixed on Win/Linux

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -4,7 +4,7 @@
         "command": "toggle_comment_django",
         "args": { "block": false },
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "text.html.django" },
+            { "key": "selector", "operator": "equal", "operand": "text.html.django & -source.js" },
         ]
     },
     {
@@ -12,7 +12,7 @@
         "command": "toggle_comment_django",
         "args": { "block": true},
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "text.html.django" },
+            { "key": "selector", "operator": "equal", "operand": "text.html.django & -source.js" },
         ]
     }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -4,7 +4,7 @@
         "command": "toggle_comment_django",
         "args": { "block": false },
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "text.html.django" },
+            { "key": "selector", "operator": "equal", "operand": "text.html.django & -source.js" },
         ]
     },
     {
@@ -12,7 +12,7 @@
         "command": "toggle_comment_django",
         "args": { "block": true},
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "text.html.django" },
+            { "key": "selector", "operator": "equal", "operand": "text.html.django & -source.js" },
         ]
     }
 ]

--- a/commands/comment.py
+++ b/commands/comment.py
@@ -128,7 +128,7 @@ class ToggleCommentDjangoCommand(sublime_plugin.TextCommand):
 
         comment_block_style = block_comments[0]
         if len(block_comments) >= 2:
-            comment_block_style = block_comments[2]
+            comment_block_style = block_comments[1]
 
         lines = view.lines(region)
 


### PR DESCRIPTION
Somehow missed the keymaps for Windows and Linux.  Also patches a potential issue with a list index error. 